### PR TITLE
Add support for A2S_INFO query challenges

### DIFF
--- a/query.h
+++ b/query.h
@@ -12,6 +12,7 @@
 #define A2S_HEADER  0xFFFFFFFF
 
 #define A2S_INFO 0x54
+#define A2S_INFO_CHALLENGE_CHECK 0x41
 #define A2S_INFO_CHECK 0x49
 #define A2S_INFO_STRING "Source Engine Query"
 


### PR DESCRIPTION
The A2S_INFO query received the same challenge packet as the other two queries. L4D2 requires this now.