### PR TITLE
Fix iterating through previous rcon commands #5

### DIFF
--- a/main_events.cpp
+++ b/main_events.cpp
@@ -33,18 +33,27 @@ bool MainWindow::eventFilter(QObject *object, QEvent *event)
             if(object == this->ui->commandText && this->commandHistory.size() > 0)
             {
                 if(!this->commandIter->hasNext())
-                {
                     this->commandIter->toFront();
+                if(this->commandIterDirection == kIterBackwards) {
+                    this->commandIter->next();
+                    if(!this->commandIter->hasNext())
+                        this->commandIter->toFront();
                 }
+
                 this->ui->commandText->setText(this->commandIter->next());
+                this->commandIterDirection = kIterForwards;
             }
             else if(object == this->ui->sendChat && this->sayHistory.size() > 0)
             {
                 if(!this->sayIter->hasNext())
-                {
                     this->sayIter->toFront();
+                if(this->sayIterDirection == kIterBackwards) {
+                    this->sayIter->next();
+                    if(!this->sayIter->hasNext())
+                        this->sayIter->toFront();
                 }
                 this->ui->sendChat->setText(this->sayIter->next());
+                this->sayIterDirection = kIterForwards;
             }
             return true;
         }
@@ -53,18 +62,26 @@ bool MainWindow::eventFilter(QObject *object, QEvent *event)
             if(object == this->ui->commandText && this->commandHistory.size() > 0)
             {
                 if(!this->commandIter->hasPrevious())
-                {
                     this->commandIter->toBack();
+                if(this->commandIterDirection == kIterForwards) {
+                    this->commandIter->previous();
+                    if(!this->commandIter->hasPrevious())
+                        this->commandIter->toBack();
                 }
                 this->ui->commandText->setText(this->commandIter->previous());
+                this->commandIterDirection = kIterBackwards;
             }
             else if(object == this->ui->sendChat && this->sayHistory.size() > 0)
             {
                 if(!this->sayIter->hasPrevious())
-                {
                     this->sayIter->toBack();
+                if(this->sayIterDirection == kIterForwards) {
+                    this->sayIter->previous();
+                    if(!this->sayIter->hasPrevious())
+                        this->sayIter->toBack();
                 }
                 this->ui->sendChat->setText(this->sayIter->previous());
+                this->sayIterDirection = kIterBackwards;
             }
             return true;
         }

--- a/main_slots.cpp
+++ b/main_slots.cpp
@@ -397,6 +397,7 @@ void MainWindow::AddRconHistory(QString chat)
 
     this->commandHistory.prepend(chat);
     this->commandIter->toFront();
+    this->commandIterDirection = kIterInit;
 }
 
 void MainWindow::AddChatHistory(QString txt)
@@ -406,4 +407,5 @@ void MainWindow::AddChatHistory(QString txt)
 
     this->sayHistory.prepend(txt);
     this->sayIter->toFront();
+    this->sayIterDirection = kIterInit;
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -17,7 +17,9 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->setupUi(this);
     setWindowTitle("Source Admin Tool");
     commandIter = new QMutableListIterator<QString>(this->commandHistory);
+    commandIterDirection = kIterInit;
     sayIter = new QMutableListIterator<QString>(this->sayHistory);
+    sayIterDirection = kIterInit;
     this->ui->commandOutput->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
 
     this->SetRconEnabled(false);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -89,6 +89,13 @@ enum : size_t
     kBrowserColCount
 };
 
+enum : uint8_t
+{
+    kIterInit,
+    kIterForwards,
+    kIterBackwards
+};
+
 namespace Ui {
 class MainWindow;
 }
@@ -165,6 +172,8 @@ private:
     QList<QString> commandHistory;
     QList<QString> sayHistory;
     QMutableListIterator<QString> *commandIter;
+    uint8_t commandIterDirection;
     QMutableListIterator<QString> *sayIter;
+    uint8_t sayIterDirection;
 };
 #endif // MAINWINDOW_H


### PR DESCRIPTION
When iterating through old commands you entered previously in the rcon command text input using the arrow up/down keys, you'd have to press the new direction twice to get the next item when changing directions.
This is annoying, so keep track of if we're switching directions and skip the value that's currently displayed in the underlying iterator.

Fixes #5