### PR TITLE
Change CI workflow run from every 3mo to every 1mo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,8 @@ on:
      - master
   workflow_dispatch:
   schedule:
-    - cron: '53 05 01 */3 *' # Artifacts expire every 3 months
+    # Artifacts expire every 90 days
+    - cron: '53 05 01 * *'
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Artifacts expire every 90 days, but CI only runs every 3 months, which is almost always going to be a slightly longer period (meaning that at this very moment, on 29-09, all artifacts are expired).

This change adjusts CI to run every 1 month to avoid that case in the future.