### PR TITLE
Fix CI workflow: Pin Qt version to 5.15.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,7 @@ jobs:
         uses: jurplel/install-qt-action@v4
         with:
           arch: ${{ matrix.qt_arch }}
+          version: '5.15.2'
           aqtversion: '>=1.2.1'
           py7zrversion: '>=0.16.1'
 


### PR DESCRIPTION
This PR fixes the CI build failure caused by mismatched Qt package metadata by adding `version: '5.15.2'` to the `install-qt-action` step.